### PR TITLE
Fix Travis build by using yarn instead of npm

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 ---
 language: node_js
 node_js:
-  - "4"
+  - "6"
 
 sudo: false
 
@@ -9,16 +9,9 @@ cache:
   directories:
     - node_modules
 
-before_install:
-  - npm config set spin false
-  - npm install -g bower
-  - bower --version
-  - npm install phantomjs-prebuilt
-  - phantomjs --version
-
 install:
-  - npm install
+  - yarn install
   - bower install
 
 script:
-  - npm test
+  - yarn run test

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "jet-vermillion-generator": "^0.1.1",
     "liquid-fire": "0.26.1",
     "loader.js": "^4.0.1",
-    "moment": "^2.10.3"
+    "moment": "^2.10.3",
+    "phantomjs-prebuilt": "^2.1.14"
   }
 }


### PR DESCRIPTION
- Make Travis use yarn instead of npm.
- Move phantomjs-prebuilt to package.json to ensure yarn installs that package (at the cost that all devs, not just Travis, have to install phantomjs-prebuilt).
- Bump Travis's node version from 4 to 6.